### PR TITLE
Update to version 2.0.9, update sysconfig/etcd for new etcd cli flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,22 @@ An RPM spec file to build and install etcd.
 
 To Install:
 
+`etcd_version='2.0.9'`
+
+`etcd_rpm_github_repo='nmilford/rpm-etcd'`
+
 `sudo yum -y install rpmdevtools && rpmdev-setuptree`
 
-`wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.spec -O ~/rpmbuild/SPECS/etcd.spec`
+`wget https://raw.github.com/${etcd_rpm_github_repo}/master/etcd.spec -O ~/rpmbuild/SPECS/etcd.spec`
 
-`wget https://github.com/coreos/etcd/releases/download/v2.0.5/etcd-v2.0.5-linux-amd64.tar.gz -O ~/rpmbuild/SOURCES/etcd-v2.0.5-linux-amd64.tar.gz`
+`wget https://github.com/coreos/etcd/releases/download/v${etcd_version}/etcd-v${etcd_version}-linux-amd64.tar.gz -O ~/rpmbuild/SOURCES/etcd-v${etcd_version}-linux-amd64.tar.gz`
 
-`wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.initd -O ~/rpmbuild/SOURCES/etcd.initd`
+`wget https://raw.github.com/${etcd_rpm_github_repo}/master/etcd.initd -O ~/rpmbuild/SOURCES/etcd.initd`
 
-`wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.sysconfig -O ~/rpmbuild/SOURCES/etcd.sysconfig`
+`wget https://raw.github.com/${etcd_rpm_github_repo}/master/etcd.sysconfig -O ~/rpmbuild/SOURCES/etcd.sysconfig`
 
-`wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.nofiles.conf -O ~/rpmbuild/SOURCES/etcd.nofiles.conf`
+`wget https://raw.github.com/${etcd_rpm_github_repo}/master/etcd.nofiles.conf -O ~/rpmbuild/SOURCES/etcd.nofiles.conf`
 
-`wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.logrotate -O ~/rpmbuild/SOURCES/etcd.logrotate`
+`wget https://raw.github.com/${etcd_rpm_github_repo}/master/etcd.logrotate -O ~/rpmbuild/SOURCES/etcd.logrotate`
 
 `rpmbuild -bb ~/rpmbuild/SPECS/etcd.spec`

--- a/etcd.spec
+++ b/etcd.spec
@@ -16,7 +16,7 @@
 #
 # sudo yum -y install rpmdevtools && rpmdev-setuptree
 # wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.spec -O ~/rpmbuild/SPECS/etcd.spec
-# wget https://github.com/coreos/etcd/releases/download/v2.0.5/etcd-v2.0.5-linux-amd64.tar.gz -O ~/rpmbuild/SOURCES/etcd-v2.0.5-linux-amd64.tar.gz
+# wget https://github.com/coreos/etcd/releases/download/v2.0.9/etcd-v2.0.9-linux-amd64.tar.gz -O ~/rpmbuild/SOURCES/etcd-v2.0.9-linux-amd64.tar.gz
 # wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.initd -O ~/rpmbuild/SOURCES/etcd.initd
 # wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.sysconfig -O ~/rpmbuild/SOURCES/etcd.sysconfig
 # wget https://raw.github.com/nmilford/rpm-etcd/master/etcd.nofiles.conf -O ~/rpmbuild/SOURCES/etcd.nofiles.conf
@@ -29,7 +29,7 @@
 %define etcd_data  %{_localstatedir}/lib/%{name}
 
 Name:      etcd
-Version:   2.0.5
+Version:   2.0.9
 Release:   1
 Summary:   A highly-available key value store for shared configuration and service discovery.
 License:   Apache 2.0
@@ -119,6 +119,7 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 
 %changelog
+* Tue Apr 10 2015 Hans-Joachim Skwirblies <hajo.skwirblies@gmail.com> bump version to 2.0.9
 * Tue Mar 17 2015 Marco Lebbink <marco@lebbink.net> 2.0.5 
 * Thu Sep 18 2014 Derek Douville <derekd@nodeprime.com> Remove golang, etcd is statically linked
 * Wed Sep 17 2014 Derek Douville <derekd@nodeprime.com> 0.4.6

--- a/etcd.sysconfig
+++ b/etcd.sysconfig
@@ -41,7 +41,7 @@ ETCD_DISCOVERY_TOKEN=""
 ETCD_NODE_NAME=$(hostname -s)
 
 # Hostname and port for the etcd server to work on.
-ETCD_LISTEN="${ETCD_PROTOCOL}${_MY_IPADDR}:4001"
+ETCD_LISTEN="${ETCD_PROTOCOL}localhost:4001,${ETCD_PROTOCOL}${_MY_IPADDR}:4001"
 
 # Directory to store log and snapshot.
 ETCD_DATA_DIR="/var/lib/etcd/"

--- a/etcd.sysconfig
+++ b/etcd.sysconfig
@@ -20,6 +20,9 @@ _MY_IPADDR=$(/sbin/ifconfig | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -
 # Daemon User
 ETCD_USER="etcd"
 
+# Communication Protocol Identifier (http://|https://)
+ETCD_PROTOCOL="http://"
+
 # Cluster Seeds
 #  You can specify a list here sepearated by commas, or leave it blank if
 #  you're playing with a single node.
@@ -38,7 +41,7 @@ ETCD_DISCOVERY_TOKEN=""
 ETCD_NODE_NAME=$(hostname -s)
 
 # Hostname and port for the etcd server to work on.
-ETCD_LISTEN="$_MY_IPADDR:4001"
+ETCD_LISTEN="${ETCD_PROTOCOL}${_MY_IPADDR}:4001"
 
 # Directory to store log and snapshot.
 ETCD_DATA_DIR="/var/lib/etcd/"
@@ -62,7 +65,7 @@ ETCD_KEY=""
 ETCD_SNAPSHOT=""
 
 # Hostname and port for the RAFT server to work on.
-RAFT_LISTEN="$_MY_IPADDR:7001"
+RAFT_LISTEN="${ETCD_PROTOCOL}${_MY_IPADDR}:7001"
 
 # Set security settings for the RAFT server.
 #  Leave blank if you do not plan to use this feature, otherwise add appropriate
@@ -74,10 +77,10 @@ RAFT_KEY=""
 # Below we build the opts to pass to the init script.
 
 ETCD_OPTS="-name=${ETCD_NODE_NAME} \
-          -addr=${ETCD_LISTEN} \
-          -peer-addr=${RAFT_LISTEN} \
+          --listen-client-urls=${ETCD_LISTEN} \
+          --listen-peer-urls=${RAFT_LISTEN} \
           -data-dir=${ETCD_DATA_DIR}"
-              
+
 if [ x$ETCD_SEEDS != "x" ]; then
   ETCD_OPTS="$ETCD_OPTS -peers=${ETCD_SEEDS}"
 fi

--- a/etcd.sysconfig
+++ b/etcd.sysconfig
@@ -37,6 +37,11 @@ ETCD_DISCOVER_ENDPOINT="https://discovery.etcd.io/"
 #  from https://discovery.etcd.io/new if you are not hosting it yourself.
 ETCD_DISCOVERY_TOKEN=""
 
+# Discovery using SRV DNS Records
+#  Configure the domain that serves the etcd cluster SRV records _etcd-server._tcp
+#  and/or _etcd-server-https._tcp
+ETCD_DISCOVERY_SRV_DOMAIN=""
+
 # This node's name as it represents itself on the cluster.
 ETCD_NODE_NAME=$(hostname -s)
 
@@ -87,6 +92,8 @@ fi
 
 if [ x$ETCD_DISCOVERY_TOKEN != "x" ]; then
   ETCD_OPTS="$ETCD_OPTS -discovery=${ETCD_DISCOVER_ENDPOINT}${ETCD_DISCOVERY_TOKEN}"
+elif [ x$ETCD_DISCOVERY_SRV_DOMAIN != "x" ]; then
+  ETCD_OPTS="$ETCD_OPTS --discovery-srv=${ETCD_DISCOVERY_SRV_DOMAIN}"
 fi
 
 if [ "$ETCD_LOGGING" == "v" ]; then

--- a/etcd.sysconfig
+++ b/etcd.sysconfig
@@ -29,10 +29,6 @@ ETCD_SEEDS=""
 #  Leave it as the public URL unless you are running your own.
 ETCD_DISCOVER_ENDPOINT="https://discovery.etcd.io/"
 
-# Specify a peer/leader to connect to upon start
-# example a hostname:7001
-ETCD_PEERS=""
-
 # Discovery Token
 #  If you are using the discovery protocol you can grab your cluster token
 #  from https://discovery.etcd.io/new if you are not hosting it yourself.
@@ -80,9 +76,8 @@ RAFT_KEY=""
 ETCD_OPTS="-name=${ETCD_NODE_NAME} \
           -addr=${ETCD_LISTEN} \
           -peer-addr=${RAFT_LISTEN} \
-          -data-dir=${ETCD_DATA_DIR} \
-          -peers=${ETCD_PEERS}"
-        
+          -data-dir=${ETCD_DATA_DIR}"
+              
 if [ x$ETCD_SEEDS != "x" ]; then
   ETCD_OPTS="$ETCD_OPTS -peers=${ETCD_SEEDS}"
 fi

--- a/etcd.sysconfig
+++ b/etcd.sysconfig
@@ -54,15 +54,6 @@ ETCD_OUT_FILE="/var/log/etcd/etcd.out"
 #   Valid options are "", "v" or "vv"
 ETCD_LOGGING=""
 
-# Max size of the cluster.
-ETCD_MAXSIZE=9
-
-# Max size of result buffer.
-ETCD_MAXRESULT=1024 
-
-# Number of retries to attempt while joining a cluster
-ETCD_RETRIES=3
-
 # Set security settings for the etcd server.
 #  Leave blank if you do not plan to use this feature, otherwise add appropriate
 #  paths.
@@ -90,11 +81,8 @@ ETCD_OPTS="-name=${ETCD_NODE_NAME} \
           -addr=${ETCD_LISTEN} \
           -peer-addr=${RAFT_LISTEN} \
           -data-dir=${ETCD_DATA_DIR} \
-          -peers=${ETCD_PEERS} \
-          -max-result-buffer=${ETCD_MAXRESULT} \
-          -max-cluster-size=${ETCD_MAXSIZE} \
-          -max-retry-attempts=${ETCD_RETRIES}"
-
+          -peers=${ETCD_PEERS}"
+        
 if [ x$ETCD_SEEDS != "x" ]; then
   ETCD_OPTS="$ETCD_OPTS -peers=${ETCD_SEEDS}"
 fi


### PR DESCRIPTION
The RPM is now created with etcd version 2.0.9, after installation a single etcd starts with the provided init script without further configuration needed. Just build the package, place it in a repo and run

```
yum -y install etcd
service etcd start
etcdctl mkdir /test
etcdctl ls /test
```
Tested on CentOS 6.6
